### PR TITLE
Henkaku website wrongly shows the bootstrap changelog on the top menu

### DIFF
--- a/_includes/header.html
+++ b/_includes/header.html
@@ -18,7 +18,7 @@
       <ul class="nav navbar-nav">
         {% assign pages = site.pages | sort:"weight"  %}
         {% for my_page in pages %}
-          {% if my_page.title %}
+          {% if my_page.title and my_page.title != "Changelog" %}
             <li {% if page.url == my_page.url %}class="active"{% endif %}>
               <a href="{{ my_page.url | prepend: site.baseurl }}">{{ my_page.title }}</a>
             </li>


### PR DESCRIPTION
![selection_016](https://cloud.githubusercontent.com/assets/20888698/21119627/59b0ef92-c0bb-11e6-9a53-899599e45ee8.png)

![selection_017](https://cloud.githubusercontent.com/assets/20888698/21119624/56e5b2a2-c0bb-11e6-8a58-90d74a2ec0a6.png)

This fixes it by excluding "Changelog" from the top menu.